### PR TITLE
fix: allow server to be hot-reloaded

### DIFF
--- a/api/packages/db_client/lib/src/db_client.dart
+++ b/api/packages/db_client/lib/src/db_client.dart
@@ -35,10 +35,19 @@ class DbClient {
     String projectId, {
     bool useEmulator = false,
   }) {
-    Firestore.initialize(
-      projectId,
-      emulator: useEmulator ? Emulator('127.0.0.1', 8081) : null,
-    );
+    try {
+      Firestore.initialize(
+        projectId,
+        emulator: useEmulator ? Emulator('127.0.0.1', 8081) : null,
+      );
+    } on Exception catch (e) {
+      if (e.toString() ==
+          'Exception: Firestore instance was already initialized') {
+        // ignore
+      } else {
+        rethrow;
+      }
+    }
 
     return DbClient(firestore: Firestore.instance);
   }

--- a/api/packages/db_client/test/src/db_client_test.dart
+++ b/api/packages/db_client/test/src/db_client_test.dart
@@ -43,6 +43,11 @@ void main() {
       expect(DbClient.initialize('A', useEmulator: true), isNotNull);
     });
 
+    test('returns instance anyway if firestore is already initialized', () {
+      expect(DbClient.initialize('A', useEmulator: true), isNotNull);
+      expect(DbClient.initialize('A', useEmulator: true), isNotNull);
+    });
+
     group('add', () {
       test('insert into firestore', () async {
         final firestore = _MockFirestore();


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
I started catching the error thrown when firestore is initialized a second time, which now allows the server to be hot reloaded.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
