### PR TITLE
refactor: pass isHost boolean as extra

### DIFF
--- a/lib/game/views/game_page.dart
+++ b/lib/game/views/game_page.dart
@@ -18,7 +18,7 @@ class GamePage extends StatelessWidget {
     return GamePage(
       key: const Key('game'),
       matchId: state.params['matchId'] ?? '',
-      isHost: state.params['isHost'] == 'true',
+      isHost: state.extra == true,
     );
   }
 

--- a/lib/match_making/views/match_making_view.dart
+++ b/lib/match_making/views/match_making_view.dart
@@ -18,7 +18,7 @@ class MatchMakingView extends StatelessWidget {
     return BlocConsumer<MatchMakingBloc, MatchMakingState>(
       listener: (previous, current) {
         if (current.status == MatchMakingStatus.completed) {
-          context.go('/game/${current.match?.id}/${current.isHost}');
+          context.go('/game/${current.match?.id}', extra: current.isHost);
         }
       },
       builder: (context, state) {

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -34,7 +34,7 @@ GoRouter createRouter() {
           ),
           GoRoute(
             name: 'game',
-            path: 'game/:matchId/:isHost',
+            path: 'game/:matchId',
             builder: GamePage.routeBuilder,
           ),
           GoRoute(

--- a/test/match_making/views/match_making_view_test.dart
+++ b/test/match_making/views/match_making_view_test.dart
@@ -72,7 +72,7 @@ void main() {
         await tester.pumpSubject(bloc, goRouter: goRouter);
 
         verify(
-          () => goRouter.go('/game/matchId/true'),
+          () => goRouter.go('/game/matchId', extra: true),
         ).called(1);
       },
     );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

In a game, there is a query parameter in the url that says whether the user is a host or not. If a user changes the value (true or false), they will be able to see the other player cards.

This PR refactors the game route so `isHost` is passed as an extra instead of parameter!

https://user-images.githubusercontent.com/75334479/227071983-2fe045f0-d7b1-455e-bddd-1d06ba891db6.mov

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
