### PR TITLE
feat: deck passes to next card when selecting one

### DIFF
--- a/lib/draft/bloc/draft_bloc.dart
+++ b/lib/draft/bloc/draft_bloc.dart
@@ -49,11 +49,7 @@ class DraftBloc extends Bloc<DraftEvent, DraftState> {
     NextCard event,
     Emitter<DraftState> emit,
   ) {
-    final cards = [...state.cards];
-
-    final lastCard = cards.removeLast();
-    cards.insert(0, lastCard);
-
+    final cards = _dismissTopCard();
     emit(state.copyWith(cards: cards));
   }
 
@@ -68,13 +64,26 @@ class DraftBloc extends Bloc<DraftEvent, DraftState> {
       topCard,
     ];
 
+    final selectionCompleted = selectedCards.length == 3;
+
+    final cards = selectionCompleted ? null : _dismissTopCard();
+
     emit(
       state.copyWith(
+        cards: cards,
         selectedCards: selectedCards,
-        status: selectedCards.length == 3
+        status: selectionCompleted
             ? DraftStateStatus.deckSelected
             : DraftStateStatus.deckLoaded,
       ),
     );
+  }
+
+  List<Card> _dismissTopCard() {
+    final cards = [...state.cards];
+
+    final lastCard = cards.removeLast();
+    cards.insert(0, lastCard);
+    return cards;
   }
 }

--- a/test/draft/bloc/draft_bloc_test.dart
+++ b/test/draft/bloc/draft_bloc_test.dart
@@ -81,6 +81,29 @@ void main() {
     );
 
     blocTest<DraftBloc, DraftState>(
+      'selects a card and changes deck on SelectCard',
+      build: () => DraftBloc(gameResource: gameResource),
+      seed: () => DraftState(
+        cards: cards,
+        selectedCards: const [],
+        status: DraftStateStatus.deckLoaded,
+      ),
+      act: (bloc) {
+        bloc.add(SelectCard());
+      },
+      expect: () => [
+        DraftState(
+          cards: [
+            cards.last,
+            ...List.generate(9, (i) => cards[i]),
+          ],
+          selectedCards: [cards.first],
+          status: DraftStateStatus.deckLoaded,
+        ),
+      ],
+    );
+
+    blocTest<DraftBloc, DraftState>(
       'status is complete when the deck is full',
       build: () => DraftBloc(gameResource: gameResource),
       seed: () => DraftState(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

When selecting a card, automatically passing to next card instead of having to press "next card"


https://user-images.githubusercontent.com/52668514/227584758-a3b43486-3b94-431a-a790-28072f02d2c5.mov



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
