### PR TITLE
fix: websocket scheme config when running app and api locally

### DIFF
--- a/lib/main_local.dart
+++ b/lib/main_local.dart
@@ -35,6 +35,7 @@ void main() async {
           baseUrl: 'http://localhost:8080',
           idTokenStream: authenticationRepository.idToken,
           refreshIdToken: authenticationRepository.refreshIdToken,
+          websocketScheme: 'ws',
         );
 
         await authenticationRepository.signInAnonymously();

--- a/packages/api_client/lib/src/api_client.dart
+++ b/packages/api_client/lib/src/api_client.dart
@@ -61,11 +61,13 @@ class ApiClient {
     PutCall putCall = http.put,
     GetCall getCall = http.get,
     WebSocket? websocket,
+    String? websocketScheme,
   })  : _base = Uri.parse(baseUrl),
         _post = postCall,
         _put = putCall,
         _get = getCall,
         _websocket = websocket,
+        _websocketScheme = websocketScheme ?? 'wss',
         _refreshIdToken = refreshIdToken {
     _idTokenSubscription = idTokenStream.listen((idToken) {
       _idToken = idToken;
@@ -78,6 +80,7 @@ class ApiClient {
   final GetCall _get;
   final Future<String?> Function() _refreshIdToken;
   final WebSocket? _websocket;
+  final String _websocketScheme;
 
   late final StreamSubscription<String?> _idTokenSubscription;
   String? _idToken;
@@ -173,7 +176,7 @@ class ApiClient {
     Map<String, String>? queryParameters,
   }) async {
     final uri = _base.replace(
-      scheme: 'wss',
+      scheme: _websocketScheme,
       path: path,
       queryParameters: queryParameters,
     );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Inject the websocket scheme into the api client so different environments can have different configurations.

Specially useful when running both api and app locally, since running the api locally requires the client to have a 'ws' scheme instead of 'wss'

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
