### PR TITLE
feat: add overlay to prevent user from joining in multiple tabs

### DIFF
--- a/api/packages/game_domain/lib/src/models/web_socket_message.dart
+++ b/api/packages/game_domain/lib/src/models/web_socket_message.dart
@@ -13,6 +13,9 @@ enum WebSocketErrorCode {
 
   /// Represents a player that is already connect to the socket.
   playerAlreadyConnected,
+
+  /// Represents an unknown error.
+  unknown,
 }
 
 /// Represents the message passed from the websocket.

--- a/api/packages/game_domain/lib/src/models/web_socket_message.g.dart
+++ b/api/packages/game_domain/lib/src/models/web_socket_message.g.dart
@@ -47,4 +47,5 @@ const _$WebSocketErrorCodeEnumMap = {
   WebSocketErrorCode.badRequest: 'badRequest',
   WebSocketErrorCode.firebaseException: 'firebaseException',
   WebSocketErrorCode.playerAlreadyConnected: 'playerAlreadyConnected',
+  WebSocketErrorCode.unknown: 'unknown',
 };

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -2,6 +2,7 @@ import 'package:api_client/api_client.dart';
 import 'package:authentication_repository/authentication_repository.dart';
 import 'package:connection_repository/connection_repository.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:game_domain/game_domain.dart';
 import 'package:game_script_machine/game_script_machine.dart';
 import 'package:go_router/go_router.dart';
@@ -9,6 +10,7 @@ import 'package:match_maker_repository/match_maker_repository.dart';
 import 'package:provider/provider.dart';
 import 'package:top_dash/app_lifecycle/app_lifecycle.dart';
 import 'package:top_dash/audio/audio_controller.dart';
+import 'package:top_dash/connection/connection.dart';
 import 'package:top_dash/l10n/l10n.dart';
 import 'package:top_dash/router/router.dart';
 import 'package:top_dash/settings/persistence/persistence.dart';
@@ -91,6 +93,11 @@ class _AppState extends State<App> {
             update: updateAudioController,
             dispose: (context, audio) => audio.dispose(),
           ),
+          BlocProvider(
+            create: (context) => ConnectionBloc(
+              connectionRepository: widget.connectionRepository,
+            )..add(const ConnectionRequested()),
+          ),
         ],
         child: Builder(
           builder: (context) {
@@ -103,6 +110,7 @@ class _AppState extends State<App> {
               scaffoldMessengerKey: scaffoldMessengerKey,
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,
+              builder: (context, child) => ConnectionOverlay(child: child),
             );
           },
         ),

--- a/lib/connection/bloc/connection_bloc.dart
+++ b/lib/connection/bloc/connection_bloc.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:connection_repository/connection_repository.dart';
+import 'package:equatable/equatable.dart';
+import 'package:game_domain/game_domain.dart';
+
+part 'connection_event.dart';
+part 'connection_state.dart';
+
+class ConnectionBloc extends Bloc<ConnectionEvent, ConnectionState> {
+  ConnectionBloc({
+    required ConnectionRepository connectionRepository,
+  })  : _connectionRepository = connectionRepository,
+        super(const ConnectionInitial()) {
+    on<ConnectionRequested>(_onConnectionRequested);
+    on<ConnectionClosed>(_onConnectionClosed);
+    on<WebSocketMessageReceived>(_onWebSocketMessageReceived);
+  }
+
+  final ConnectionRepository _connectionRepository;
+  StreamSubscription<WebSocketMessage>? _messageSubscription;
+
+  @override
+  Future<void> close() async {
+    await _messageSubscription?.cancel();
+    _connectionRepository.close();
+    return super.close();
+  }
+
+  Future<void> _onConnectionRequested(
+    ConnectionRequested event,
+    Emitter<ConnectionState> emit,
+  ) async {
+    emit(const ConnectionInProgress());
+    try {
+      await _connectionRepository.connect();
+      _messageSubscription = _connectionRepository.messages.listen(
+        (message) => add(WebSocketMessageReceived(message)),
+        onDone: () => add(const ConnectionClosed()),
+      );
+    } catch (e, s) {
+      emit(const ConnectionFailure(WebSocketErrorCode.unknown));
+      addError(e, s);
+    }
+  }
+
+  Future<void> _onConnectionClosed(
+    ConnectionClosed event,
+    Emitter<ConnectionState> emit,
+  ) async {
+    emit(const ConnectionInitial());
+    await _messageSubscription?.cancel();
+  }
+
+  Future<void> _onWebSocketMessageReceived(
+    WebSocketMessageReceived event,
+    Emitter<ConnectionState> emit,
+  ) async {
+    final message = event.message;
+    if (message.messageType == MessageType.connected) {
+      emit(const ConnectionSuccess());
+    } else if (message.messageType == MessageType.error) {
+      final payload = message.payload! as WebSocketErrorPayload;
+      emit(ConnectionFailure(payload.errorCode));
+    }
+  }
+}

--- a/lib/connection/bloc/connection_event.dart
+++ b/lib/connection/bloc/connection_event.dart
@@ -1,0 +1,25 @@
+part of 'connection_bloc.dart';
+
+abstract class ConnectionEvent extends Equatable {
+  const ConnectionEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class ConnectionRequested extends ConnectionEvent {
+  const ConnectionRequested();
+}
+
+class ConnectionClosed extends ConnectionEvent {
+  const ConnectionClosed();
+}
+
+class WebSocketMessageReceived extends ConnectionEvent {
+  const WebSocketMessageReceived(this.message);
+
+  final WebSocketMessage message;
+
+  @override
+  List<Object> get props => [message];
+}

--- a/lib/connection/bloc/connection_state.dart
+++ b/lib/connection/bloc/connection_state.dart
@@ -1,0 +1,29 @@
+part of 'connection_bloc.dart';
+
+abstract class ConnectionState extends Equatable {
+  const ConnectionState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class ConnectionInitial extends ConnectionState {
+  const ConnectionInitial();
+}
+
+class ConnectionInProgress extends ConnectionState {
+  const ConnectionInProgress();
+}
+
+class ConnectionSuccess extends ConnectionState {
+  const ConnectionSuccess();
+}
+
+class ConnectionFailure extends ConnectionState {
+  const ConnectionFailure(this.error);
+
+  final WebSocketErrorCode error;
+
+  @override
+  List<Object> get props => [error];
+}

--- a/lib/connection/connection.dart
+++ b/lib/connection/connection.dart
@@ -1,0 +1,2 @@
+export 'bloc/connection_bloc.dart';
+export 'view/view.dart';

--- a/lib/connection/view/connection_overlay.dart
+++ b/lib/connection/view/connection_overlay.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart' hide ConnectionState;
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:game_domain/game_domain.dart';
+import 'package:top_dash/connection/connection.dart';
+import 'package:top_dash/l10n/l10n.dart';
+
+class ConnectionOverlay extends StatelessWidget {
+  const ConnectionOverlay({super.key, this.child});
+
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ConnectionBloc, ConnectionState>(
+      builder: (context, state) {
+        if (state is ConnectionFailure) {
+          return _ConnectionOverlayFailure(
+            error: state.error,
+            child: child,
+          );
+        }
+
+        return child ?? const SizedBox.shrink();
+      },
+    );
+  }
+}
+
+class _ConnectionOverlayFailure extends StatelessWidget {
+  const _ConnectionOverlayFailure({
+    required this.error,
+    required this.child,
+  });
+
+  final WebSocketErrorCode error;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        if (child != null) child!,
+        Positioned.fill(
+          child: ColoredBox(
+            color: Colors.white.withOpacity(0.9),
+            child: Center(
+              child: Text(
+                error == WebSocketErrorCode.playerAlreadyConnected
+                    ? context.l10n.playerAlreadyConnectedError
+                    : context.l10n.unknownConnectionError,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/connection/view/view.dart
+++ b/lib/connection/view/view.dart
@@ -1,0 +1,1 @@
+export 'connection_overlay.dart';

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -255,5 +255,13 @@
   "quitGameDialogDescription": "You will lose your current hand and active winning streak.",
   "@quitGameDialogDescription": {
     "description": "Description of the quit game dialog"
+  },
+  "playerAlreadyConnectedError": "Please only use one tab at a time.",
+  "@playerAlreadyConnectedError": {
+    "description": "Error message shown when user connects in multiple tabs"
+  },
+  "unknownConnectionError": "Unable to connect. Please try again in a few moments.",
+  "@unknownConnectionError": {
+    "description": "Error message shown when an unknown error occurs while connecting"
   }
 }

--- a/test/app/view/app_test.dart
+++ b/test/app/view/app_test.dart
@@ -9,6 +9,7 @@ import 'package:match_maker_repository/match_maker_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:top_dash/app/app.dart';
 import 'package:top_dash/audio/audio_controller.dart';
+import 'package:top_dash/connection/connection.dart';
 import 'package:top_dash/how_to_play/how_to_play.dart';
 import 'package:top_dash/main_menu/main_menu_screen.dart';
 import 'package:top_dash/prompt/prompt.dart';
@@ -40,7 +41,12 @@ class _MockLeaderboardResource extends Mock implements LeaderboardResource {}
 
 class _MockMatchMakerRepository extends Mock implements MatchMakerRepository {}
 
-class _MockConnectionRepository extends Mock implements ConnectionRepository {}
+class _MockConnectionRepository extends Mock implements ConnectionRepository {
+  _MockConnectionRepository() {
+    when(connect).thenAnswer((_) async {});
+    when(() => messages).thenAnswer((_) => const Stream.empty());
+  }
+}
 
 class _MockMatchSolver extends Mock implements MatchSolver {}
 
@@ -85,6 +91,22 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('SnackBar'), findsOneWidget);
+    });
+
+    testWidgets('wraps everything in a ConnectionOverlay', (tester) async {
+      await tester.pumpWidget(
+        App(
+          settingsPersistence: MemoryOnlySettingsPersistence(),
+          apiClient: apiClient,
+          matchMakerRepository: _MockMatchMakerRepository(),
+          connectionRepository: _MockConnectionRepository(),
+          matchSolver: _MockMatchSolver(),
+          gameScriptMachine: _MockGameScriptEngine(),
+          user: _MockUser(),
+        ),
+      );
+
+      expect(find.byType(ConnectionOverlay), findsOneWidget);
     });
 
     group('updateAudioController', () {

--- a/test/connection/bloc/connection_bloc_test.dart
+++ b/test/connection/bloc/connection_bloc_test.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:connection_repository/connection_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:game_domain/game_domain.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:top_dash/connection/connection.dart';
+
+class _MockConnectionRepository extends Mock implements ConnectionRepository {}
+
+void main() {
+  group('ConnectionBloc', () {
+    late ConnectionRepository connectionRepository;
+    late StreamController<WebSocketMessage> messageController;
+
+    setUp(() {
+      connectionRepository = _MockConnectionRepository();
+      messageController = StreamController<WebSocketMessage>();
+      when(() => connectionRepository.messages)
+          .thenAnswer((_) => messageController.stream);
+    });
+
+    group('on ConnectionRequested', () {
+      blocTest<ConnectionBloc, ConnectionState>(
+        'emits ConnectionInProgress when connection is successful',
+        setUp: () {
+          when(() => connectionRepository.connect()).thenAnswer((_) async {});
+        },
+        build: () => ConnectionBloc(connectionRepository: connectionRepository),
+        act: (bloc) => bloc.add(const ConnectionRequested()),
+        expect: () => [
+          const ConnectionInProgress(),
+        ],
+        verify: (_) {
+          verify(() => connectionRepository.connect()).called(1);
+          verify(() => connectionRepository.messages).called(1);
+        },
+      );
+      blocTest<ConnectionBloc, ConnectionState>(
+        'emits [ConnectionInProgress, ConnectionSuccessful] when connection is '
+        'successful and a connected message is received',
+        setUp: () {
+          when(() => connectionRepository.connect()).thenAnswer((_) async {});
+          messageController.onListen = () {
+            messageController.add(const WebSocketMessage.connected());
+          };
+        },
+        build: () => ConnectionBloc(connectionRepository: connectionRepository),
+        act: (bloc) => bloc.add(const ConnectionRequested()),
+        expect: () => [
+          const ConnectionInProgress(),
+          const ConnectionSuccess(),
+        ],
+        verify: (_) {
+          verify(() => connectionRepository.connect()).called(1);
+          verify(() => connectionRepository.messages).called(1);
+        },
+      );
+
+      blocTest<ConnectionBloc, ConnectionState>(
+        'emits [ConnectionInProgress, ConnectionFailure] when connection is '
+        'successful and an error message is received',
+        setUp: () {
+          when(() => connectionRepository.connect()).thenAnswer((_) async {});
+          messageController.onListen = () {
+            messageController.add(
+              WebSocketMessage.error(WebSocketErrorCode.playerAlreadyConnected),
+            );
+          };
+        },
+        build: () => ConnectionBloc(connectionRepository: connectionRepository),
+        act: (bloc) => bloc.add(const ConnectionRequested()),
+        expect: () => [
+          const ConnectionInProgress(),
+          const ConnectionFailure(WebSocketErrorCode.playerAlreadyConnected),
+        ],
+        verify: (_) {
+          verify(() => connectionRepository.connect()).called(1);
+          verify(() => connectionRepository.messages).called(1);
+        },
+      );
+
+      blocTest<ConnectionBloc, ConnectionState>(
+        'emits ConnectionInitial when messages stream is closed',
+        setUp: () {
+          when(() => connectionRepository.connect()).thenAnswer((_) async {});
+          messageController.onListen = () {
+            messageController.close();
+          };
+        },
+        build: () => ConnectionBloc(connectionRepository: connectionRepository),
+        act: (bloc) => bloc.add(const ConnectionRequested()),
+        expect: () => [
+          const ConnectionInProgress(),
+          const ConnectionInitial(),
+        ],
+        verify: (_) {
+          verify(() => connectionRepository.connect()).called(1);
+          verify(() => connectionRepository.messages).called(1);
+        },
+      );
+
+      blocTest<ConnectionBloc, ConnectionState>(
+        'emits [ConnectionInProgress, ConnectionFailure] '
+        'when connection is not successful',
+        setUp: () {
+          when(() => connectionRepository.connect()).thenThrow(Exception());
+        },
+        build: () => ConnectionBloc(connectionRepository: connectionRepository),
+        act: (bloc) => bloc.add(const ConnectionRequested()),
+        expect: () => [
+          const ConnectionInProgress(),
+          const ConnectionFailure(WebSocketErrorCode.unknown),
+        ],
+        verify: (_) {
+          verify(() => connectionRepository.connect()).called(1);
+        },
+        errors: () => [
+          isA<Exception>(),
+        ],
+      );
+    });
+  });
+}

--- a/test/connection/bloc/connection_event_test.dart
+++ b/test/connection/bloc/connection_event_test.dart
@@ -1,0 +1,41 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:game_domain/game_domain.dart';
+import 'package:top_dash/connection/connection.dart';
+
+void main() {
+  group('ConnectionEvent', () {
+    group('ConnectionRequested', () {
+      test('uses value equality', () {
+        expect(
+          ConnectionRequested(),
+          equals(ConnectionRequested()),
+        );
+      });
+    });
+
+    group('ConnectionClosed', () {
+      test('uses value equality', () {
+        expect(
+          ConnectionClosed(),
+          equals(ConnectionClosed()),
+        );
+      });
+    });
+
+    group('WebSocketMessageReceived', () {
+      test('uses value equality', () {
+        final a = WebSocketMessageReceived(WebSocketMessage.connected());
+        final b = WebSocketMessageReceived(WebSocketMessage.connected());
+        final c = WebSocketMessageReceived(
+          WebSocketMessage.error(
+            WebSocketErrorCode.playerAlreadyConnected,
+          ),
+        );
+        expect(a, equals(b));
+        expect(a, isNot(equals(c)));
+      });
+    });
+  });
+}

--- a/test/connection/bloc/connection_state_test.dart
+++ b/test/connection/bloc/connection_state_test.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:game_domain/game_domain.dart';
+import 'package:top_dash/connection/connection.dart';
+
+void main() {
+  group('ConnectionState', () {
+    group('ConnectionInitial', () {
+      test('uses value equality', () {
+        expect(
+          ConnectionInitial(),
+          equals(ConnectionInitial()),
+        );
+      });
+    });
+
+    group('ConnectionInProgress', () {
+      test('uses value equality', () {
+        expect(
+          ConnectionInProgress(),
+          equals(ConnectionInProgress()),
+        );
+      });
+    });
+
+    group('ConnectionSuccess', () {
+      test('uses value equality', () {
+        expect(
+          ConnectionSuccess(),
+          equals(ConnectionSuccess()),
+        );
+      });
+    });
+
+    group('ConnectionFailure', () {
+      test('uses value equality', () {
+        expect(
+          ConnectionFailure(WebSocketErrorCode.playerAlreadyConnected),
+          equals(ConnectionFailure(WebSocketErrorCode.playerAlreadyConnected)),
+        );
+        expect(
+          ConnectionFailure(WebSocketErrorCode.playerAlreadyConnected),
+          isNot(
+            equals(
+              ConnectionFailure(WebSocketErrorCode.firebaseException),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}

--- a/test/connection/view/connection_overlay_test.dart
+++ b/test/connection/view/connection_overlay_test.dart
@@ -1,0 +1,76 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart' hide ConnectionState;
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:game_domain/game_domain.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:top_dash/connection/connection.dart';
+
+import '../../helpers/helpers.dart';
+
+class _MockConnectionBloc extends MockBloc<ConnectionEvent, ConnectionState>
+    implements ConnectionBloc {}
+
+void main() {
+  group('ConnectionOverlay', () {
+    const child = SizedBox(key: Key('child'));
+    late ConnectionBloc connectionBloc;
+
+    setUp(() {
+      connectionBloc = _MockConnectionBloc();
+    });
+
+    Widget buildSubject() => BlocProvider.value(
+          value: connectionBloc,
+          child: const ConnectionOverlay(child: child),
+        );
+
+    group('when state is not ConnectionFailure', () {
+      setUp(() {
+        when(() => connectionBloc.state).thenReturn(const ConnectionSuccess());
+      });
+      testWidgets('shows child', (tester) async {
+        await tester.pumpApp(buildSubject());
+
+        expect(find.byWidget(child), findsOneWidget);
+      });
+    });
+
+    group('when state is  ConnectionFailure', () {
+      setUp(() {
+        when(() => connectionBloc.state).thenReturn(
+          const ConnectionFailure(
+            WebSocketErrorCode.unknown,
+          ),
+        );
+      });
+
+      testWidgets('shows child', (tester) async {
+        await tester.pumpApp(buildSubject());
+
+        expect(find.byWidget(child), findsOneWidget);
+      });
+
+      testWidgets('shows unknown error code', (tester) async {
+        await tester.pumpApp(buildSubject());
+
+        expect(find.text(tester.l10n.unknownConnectionError), findsOneWidget);
+      });
+
+      testWidgets('shows player already connected error code', (tester) async {
+        when(() => connectionBloc.state).thenReturn(
+          const ConnectionFailure(
+            WebSocketErrorCode.playerAlreadyConnected,
+          ),
+        );
+
+        await tester.pumpApp(buildSubject());
+
+        expect(
+          find.text(tester.l10n.playerAlreadyConnectedError),
+          findsOneWidget,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
I added an overlay that displays on websocket errors.

<img width="1201" alt="Screenshot 2023-04-06 at 11 10 13 AM" src="https://user-images.githubusercontent.com/18384371/230422658-cf1ee5a8-2fc2-40b7-9cec-7cfde8d6d802.png">


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
