### PR TITLE
refactor: rename duplicate match class

### DIFF
--- a/lib/game/bloc/game_bloc.dart
+++ b/lib/game/bloc/game_bloc.dart
@@ -7,7 +7,7 @@ import 'package:connection_repository/connection_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:game_domain/game_domain.dart';
-import 'package:match_maker_repository/match_maker_repository.dart' as repo;
+import 'package:match_maker_repository/match_maker_repository.dart';
 import 'package:top_dash_ui/top_dash_ui.dart';
 
 part 'game_event.dart';
@@ -16,7 +16,7 @@ part 'game_state.dart';
 class GameBloc extends Bloc<GameEvent, GameState> {
   GameBloc({
     required GameResource gameResource,
-    required repo.MatchMakerRepository matchMakerRepository,
+    required MatchMakerRepository matchMakerRepository,
     required MatchSolver matchSolver,
     required User user,
     required this.isHost,
@@ -40,7 +40,7 @@ class GameBloc extends Bloc<GameEvent, GameState> {
   }
 
   final GameResource _gameResource;
-  final repo.MatchMakerRepository _matchMakerRepository;
+  final MatchMakerRepository _matchMakerRepository;
   final MatchSolver _matchSolver;
   final User _user;
   final bool isHost;
@@ -52,7 +52,7 @@ class GameBloc extends Bloc<GameEvent, GameState> {
   static const _turnMaxTime = 10;
 
   StreamSubscription<MatchState>? _stateSubscription;
-  StreamSubscription<repo.Match>? _opponentDisconnectSubscription;
+  StreamSubscription<DraftMatch>? _opponentDisconnectSubscription;
   StreamSubscription<ScoreCard>? _scoreSubscription;
 
   Future<void> _onMatchRequested(

--- a/lib/match_making/bloc/match_making_bloc.dart
+++ b/lib/match_making/bloc/match_making_bloc.dart
@@ -4,8 +4,7 @@ import 'package:api_client/api_client.dart';
 import 'package:connection_repository/connection_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-// TODO(kirpal): Why are there two different Match classes?
-import 'package:game_domain/game_domain.dart' hide Match;
+import 'package:game_domain/game_domain.dart';
 import 'package:match_maker_repository/match_maker_repository.dart';
 
 part 'match_making_event.dart';
@@ -137,7 +136,7 @@ class MatchMakingBloc extends Bloc<MatchMakingEvent, MatchMakingState> {
   }
 
   Future<void> _waitGuestToJoin({
-    required Match match,
+    required DraftMatch match,
     required Emitter<MatchMakingState> emit,
   }) async {
     final stream = _matchMakerRepository
@@ -146,7 +145,7 @@ class MatchMakingBloc extends Bloc<MatchMakingEvent, MatchMakingState> {
 
     emit(state.copyWith(match: match));
 
-    late StreamSubscription<Match> subscription;
+    late StreamSubscription<DraftMatch> subscription;
 
     subscription = stream.listen((newMatch) {
       emit(

--- a/lib/match_making/bloc/match_making_state.dart
+++ b/lib/match_making/bloc/match_making_state.dart
@@ -20,12 +20,12 @@ class MatchMakingState extends Equatable {
           status: MatchMakingStatus.initial,
         );
 
-  final Match? match;
+  final DraftMatch? match;
   final MatchMakingStatus status;
   final bool isHost;
 
   MatchMakingState copyWith({
-    Match? match,
+    DraftMatch? match,
     MatchMakingStatus? status,
     bool? isHost,
   }) {

--- a/packages/match_maker_repository/lib/src/match_maker_repository.dart
+++ b/packages/match_maker_repository/lib/src/match_maker_repository.dart
@@ -3,7 +3,7 @@ import 'dart:math' as math;
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
-import 'package:game_domain/game_domain.dart' hide Match;
+import 'package:game_domain/game_domain.dart';
 import 'package:match_maker_repository/match_maker_repository.dart';
 import 'package:uuid/uuid.dart';
 
@@ -58,7 +58,7 @@ class MatchMakerRepository {
   late final math.Random _randomGenerator;
 
   /// Watches a match.
-  Stream<Match> watchMatch(String id) {
+  Stream<DraftMatch> watchMatch(String id) {
     return collection.doc(id).snapshots().map((snapshot) {
       final id = snapshot.id;
       final data = snapshot.data()!;
@@ -67,7 +67,7 @@ class MatchMakerRepository {
       final hostConnected = data['hostConnected'] as bool?;
       final guestConnected = data['guestConnected'] as bool?;
 
-      return Match(
+      return DraftMatch(
         id: id,
         host: host,
         guest: guest == _emptyKey || guest == _inviteKey ? null : guest,
@@ -110,7 +110,7 @@ class MatchMakerRepository {
     });
   }
 
-  Match _mapMatchQueryElement(
+  DraftMatch _mapMatchQueryElement(
     QueryDocumentSnapshot<Map<String, dynamic>> element,
   ) {
     final id = element.id;
@@ -120,7 +120,7 @@ class MatchMakerRepository {
     final guestConnected = data['guestConnected'] as bool?;
     final inviteCode = data['inviteCode'] as String?;
 
-    return Match(
+    return DraftMatch(
       id: id,
       host: host,
       hostConnected: hostConnected ?? false,
@@ -140,7 +140,7 @@ class MatchMakerRepository {
   }
 
   /// Finds a match.
-  Future<Match> findMatch(String id, {int retryNumber = 0}) async {
+  Future<DraftMatch> findMatch(String id, {int retryNumber = 0}) async {
     /// Find a match that is not full and has
     /// been updated in the last 4 seconds.
     final matchesResult = await collection
@@ -186,13 +186,13 @@ class MatchMakerRepository {
   }
 
   /// Creates a private match that can only be joined with an invitation code.
-  Future<Match> createPrivateMatch(String id) => _createMatch(
+  Future<DraftMatch> createPrivateMatch(String id) => _createMatch(
         id,
         inviteOnly: true,
       );
 
   /// Searches for and join a private match. Returns null if none is found.
-  Future<Match?> joinPrivateMatch({
+  Future<DraftMatch?> joinPrivateMatch({
     required String guestId,
     required String inviteCode,
   }) async {
@@ -219,7 +219,7 @@ class MatchMakerRepository {
     return null;
   }
 
-  Future<Match> _createMatch(String id, {bool inviteOnly = false}) async {
+  Future<DraftMatch> _createMatch(String id, {bool inviteOnly = false}) async {
     final inviteCode = inviteOnly ? _inviteCode() : null;
     final result = await collection.add({
       'host': id,
@@ -233,7 +233,7 @@ class MatchMakerRepository {
       'guestPlayedCards': const <String>[],
       'hostStartsMatch': _randomGenerator.nextBool(),
     });
-    return Match(
+    return DraftMatch(
       id: result.id,
       host: id,
       inviteCode: inviteCode,

--- a/packages/match_maker_repository/lib/src/models/draft_match.dart
+++ b/packages/match_maker_repository/lib/src/models/draft_match.dart
@@ -1,11 +1,11 @@
 import 'package:equatable/equatable.dart';
 
-/// {@template match}
-/// A class representing a match between a host and a guest.
+/// {@template draft_match}
+/// A class representing a partially-formed match between a host and a guest.
 /// {@endtemplate}
-class Match extends Equatable {
-  /// {@macro match}
-  const Match({
+class DraftMatch extends Equatable {
+  /// {@macro draft_match}
+  const DraftMatch({
     required this.id,
     required this.host,
     this.guest,
@@ -34,11 +34,11 @@ class Match extends Equatable {
   /// If the guest is connected or disconnected from the match.
   final bool guestConnected;
 
-  /// Returns a new [Match] object with a new [guest] property.
-  Match copyWithGuest({
+  /// Returns a new [DraftMatch] object with a new [guest] property.
+  DraftMatch copyWithGuest({
     required String guest,
   }) {
-    return Match(
+    return DraftMatch(
       id: id,
       host: host,
       guest: guest,

--- a/packages/match_maker_repository/lib/src/models/models.dart
+++ b/packages/match_maker_repository/lib/src/models/models.dart
@@ -1,1 +1,1 @@
-export 'match.dart';
+export 'draft_match.dart';

--- a/packages/match_maker_repository/test/src/match_maker_repository_test.dart
+++ b/packages/match_maker_repository/test/src/match_maker_repository_test.dart
@@ -5,7 +5,7 @@ import 'dart:math' as math;
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:game_domain/game_domain.dart' hide Match;
+import 'package:game_domain/game_domain.dart';
 import 'package:match_maker_repository/match_maker_repository.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -79,7 +79,7 @@ void main() {
       );
     });
 
-    void mockQueryResult({List<Match> matches = const []}) {
+    void mockQueryResult({List<DraftMatch> matches = const []}) {
       when(() => collection.where('guest', isEqualTo: 'EMPTY'))
           .thenReturn(collection);
       when(
@@ -109,7 +109,7 @@ void main() {
 
     void mockInviteQueryResult(
       String inviteCode, {
-      List<Match> matches = const [],
+      List<DraftMatch> matches = const [],
     }) {
       when(() => collection.where('guest', isEqualTo: 'INVITE'))
           .thenReturn(collection);
@@ -251,7 +251,7 @@ void main() {
       expect(
         match,
         equals(
-          Match(
+          DraftMatch(
             id: 'matchId',
             host: 'hostId',
           ),
@@ -279,7 +279,7 @@ void main() {
       expect(
         match,
         equals(
-          Match(
+          DraftMatch(
             id: 'matchId',
             host: 'hostId',
             inviteCode: 'inviteCode',
@@ -303,7 +303,7 @@ void main() {
       mockInviteQueryResult(
         'inviteCode',
         matches: [
-          Match(
+          DraftMatch(
             id: 'matchId',
             host: 'hostId',
             inviteCode: 'inviteCode',
@@ -319,7 +319,7 @@ void main() {
       expect(
         match,
         equals(
-          Match(
+          DraftMatch(
             id: 'matchId',
             host: 'hostId',
             guest: 'guestId',
@@ -334,7 +334,7 @@ void main() {
       () async {
         mockQueryResult(
           matches: [
-            Match(
+            DraftMatch(
               id: 'match123',
               host: 'host123',
             ),
@@ -346,7 +346,7 @@ void main() {
         expect(
           match,
           equals(
-            Match(
+            DraftMatch(
               id: 'match123',
               host: 'host123',
               guest: 'guest123',
@@ -361,7 +361,7 @@ void main() {
       () async {
         mockQueryResult(
           matches: [
-            Match(
+            DraftMatch(
               id: 'match123',
               host: 'host123',
             ),
@@ -383,7 +383,7 @@ void main() {
 
       mockSnapshots('123', streamController.stream);
 
-      final values = <Match>[];
+      final values = <DraftMatch>[];
       final subscription =
           matchMakerRepository.watchMatch('123').listen(values.add);
 
@@ -403,7 +403,7 @@ void main() {
       expect(
         values,
         equals([
-          Match(
+          DraftMatch(
             id: '123',
             host: 'host1',
             guest: 'guest1',
@@ -422,7 +422,7 @@ void main() {
 
       mockSnapshots('123', streamController.stream);
 
-      final values = <Match>[];
+      final values = <DraftMatch>[];
       final subscription =
           matchMakerRepository.watchMatch('123').listen(values.add);
 
@@ -440,7 +440,7 @@ void main() {
       expect(
         values,
         equals([
-          Match(
+          DraftMatch(
             id: '123',
             host: 'host1',
           )

--- a/test/game/bloc/game_bloc_test.dart
+++ b/test/game/bloc/game_bloc_test.dart
@@ -9,7 +9,7 @@ import 'package:connection_repository/connection_repository.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:game_domain/game_domain.dart';
-import 'package:match_maker_repository/match_maker_repository.dart' as repo;
+import 'package:match_maker_repository/match_maker_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:top_dash/game/game.dart';
 import 'package:top_dash_ui/top_dash_ui.dart';
@@ -18,8 +18,7 @@ class _MockGameResource extends Mock implements GameResource {}
 
 class _MockConnectionRepository extends Mock implements ConnectionRepository {}
 
-class _MockMatchMakerRepository extends Mock
-    implements repo.MatchMakerRepository {}
+class _MockMatchMakerRepository extends Mock implements MatchMakerRepository {}
 
 class _MockMatchSolver extends Mock implements MatchSolver {}
 
@@ -44,10 +43,10 @@ void main() {
     );
 
     late StreamController<MatchState> matchStateController;
-    late StreamController<repo.Match> matchController;
+    late StreamController<DraftMatch> matchController;
     late StreamController<ScoreCard> scoreController;
     late GameResource gameResource;
-    late repo.MatchMakerRepository matchMakerRepository;
+    late MatchMakerRepository matchMakerRepository;
     late MatchSolver matchSolver;
     late User user;
     late ConnectionRepository connectionRepository;
@@ -1348,7 +1347,7 @@ void main() {
         act: (bloc) {
           bloc.add(ManagePlayerPresence(match.id));
           matchController.add(
-            repo.Match(
+            DraftMatch(
               id: 'matchId',
               host: 'hostId',
               guest: 'guestId',
@@ -1375,7 +1374,7 @@ void main() {
         act: (bloc) {
           bloc.add(ManagePlayerPresence(match.id));
           matchController.add(
-            repo.Match(
+            DraftMatch(
               id: 'matchId',
               host: 'hostId',
               guest: 'guestId',
@@ -1402,7 +1401,7 @@ void main() {
         act: (bloc) {
           bloc.add(ManagePlayerPresence(match.id));
           matchController.add(
-            repo.Match(
+            DraftMatch(
               id: 'matchId',
               host: 'hostId',
               guest: 'guestId',
@@ -1435,7 +1434,7 @@ void main() {
         act: (bloc) {
           bloc.add(ManagePlayerPresence(match.id));
           matchController.add(
-            repo.Match(
+            DraftMatch(
               id: 'matchId',
               host: 'hostId',
               guest: 'guestId',
@@ -1472,7 +1471,7 @@ void main() {
         act: (bloc) {
           bloc.add(ManagePlayerPresence(match.id));
           matchController.add(
-            repo.Match(
+            DraftMatch(
               id: 'matchId',
               host: 'hostId',
               guest: 'guestId',

--- a/test/match_making/bloc/match_making_bloc_test.dart
+++ b/test/match_making/bloc/match_making_bloc_test.dart
@@ -7,8 +7,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:connection_repository/connection_repository.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
-// TODO(kirpal): Why are there two match classes?
-import 'package:game_domain/game_domain.dart' hide Match;
+import 'package:game_domain/game_domain.dart';
 import 'package:match_maker_repository/match_maker_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:top_dash/match_making/match_making.dart';
@@ -24,7 +23,7 @@ void main() {
     late GameResource gameResource;
     late MatchMakerRepository matchMakerRepository;
     late ConnectionRepository connectionRepository;
-    late StreamController<Match> watchController;
+    late StreamController<DraftMatch> watchController;
     const deckId = 'deckId';
     final cardIds = ['a', 'b', 'c'];
 
@@ -85,7 +84,7 @@ void main() {
       ),
       setUp: () {
         when(() => matchMakerRepository.findMatch(deckId)).thenAnswer(
-          (_) async => Match(
+          (_) async => DraftMatch(
             id: '',
             host: '',
             guest: deckId,
@@ -99,7 +98,7 @@ void main() {
         ),
         MatchMakingState(
           status: MatchMakingStatus.completed,
-          match: Match(
+          match: DraftMatch(
             id: '',
             host: '',
             guest: deckId,
@@ -153,7 +152,7 @@ void main() {
       ),
       setUp: () {
         when(() => matchMakerRepository.findMatch(deckId)).thenAnswer(
-          (_) async => Match(
+          (_) async => DraftMatch(
             id: '',
             host: deckId,
           ),
@@ -166,7 +165,7 @@ void main() {
         ),
         MatchMakingState(
           status: MatchMakingStatus.processing,
-          match: Match(
+          match: DraftMatch(
             id: '',
             host: deckId,
           ),
@@ -186,7 +185,7 @@ void main() {
 
     test('completes the match when is host and a guest joins', () async {
       when(() => matchMakerRepository.findMatch(deckId)).thenAnswer(
-        (_) async => Match(
+        (_) async => DraftMatch(
           id: '',
           host: deckId,
         ),
@@ -204,7 +203,7 @@ void main() {
         equals(
           MatchMakingState(
             status: MatchMakingStatus.processing,
-            match: Match(
+            match: DraftMatch(
               id: '',
               host: deckId,
             ),
@@ -213,7 +212,7 @@ void main() {
       );
 
       watchController.add(
-        Match(
+        DraftMatch(
           id: '',
           host: deckId,
           guest: '',
@@ -225,7 +224,7 @@ void main() {
         equals(
           MatchMakingState(
             status: MatchMakingStatus.completed,
-            match: Match(
+            match: DraftMatch(
               id: '',
               host: deckId,
               guest: '',
@@ -239,7 +238,7 @@ void main() {
     test('emits timeout when guest never joins host', () async {
       fakeAsync((async) {
         when(() => matchMakerRepository.findMatch(deckId)).thenAnswer(
-          (_) async => Match(
+          (_) async => DraftMatch(
             id: '',
             host: deckId,
           ),
@@ -260,7 +259,7 @@ void main() {
           equals(
             MatchMakingState(
               status: MatchMakingStatus.timeout,
-              match: Match(
+              match: DraftMatch(
                 id: '',
                 host: deckId,
               ),
@@ -280,7 +279,7 @@ void main() {
       ),
       setUp: () {
         when(() => matchMakerRepository.createPrivateMatch(deckId)).thenAnswer(
-          (_) async => Match(
+          (_) async => DraftMatch(
             id: '',
             host: deckId,
           ),
@@ -293,7 +292,7 @@ void main() {
         ),
         MatchMakingState(
           status: MatchMakingStatus.processing,
-          match: Match(
+          match: DraftMatch(
             id: '',
             host: deckId,
           ),
@@ -350,7 +349,7 @@ void main() {
             inviteCode: 'invite',
           ),
         ).thenAnswer(
-          (_) async => Match(
+          (_) async => DraftMatch(
             id: '',
             guest: deckId,
             host: 'hostId',
@@ -364,7 +363,7 @@ void main() {
         ),
         MatchMakingState(
           status: MatchMakingStatus.completed,
-          match: Match(
+          match: DraftMatch(
             id: '',
             guest: deckId,
             host: 'hostId',

--- a/test/match_making/bloc/match_making_state_test.dart
+++ b/test/match_making/bloc/match_making_state_test.dart
@@ -10,7 +10,7 @@ void main() {
       expect(
         MatchMakingState(
           status: MatchMakingStatus.initial,
-          match: Match(
+          match: DraftMatch(
             id: '',
             host: '',
           ),
@@ -34,7 +34,7 @@ void main() {
       expect(
         MatchMakingState(
           status: MatchMakingStatus.initial,
-          match: Match(
+          match: DraftMatch(
             id: '',
             host: '',
           ),
@@ -42,7 +42,7 @@ void main() {
         equals(
           MatchMakingState(
             status: MatchMakingStatus.initial,
-            match: Match(
+            match: DraftMatch(
               id: '',
               host: '',
             ),
@@ -53,7 +53,7 @@ void main() {
       expect(
         MatchMakingState(
           status: MatchMakingStatus.failed,
-          match: Match(
+          match: DraftMatch(
             id: '',
             host: '',
           ),
@@ -62,7 +62,7 @@ void main() {
           equals(
             MatchMakingState(
               status: MatchMakingStatus.initial,
-              match: Match(
+              match: DraftMatch(
                 id: '',
                 host: '',
               ),
@@ -74,7 +74,7 @@ void main() {
       expect(
         MatchMakingState(
           status: MatchMakingStatus.initial,
-          match: Match(
+          match: DraftMatch(
             id: '1',
             host: '',
           ),
@@ -83,7 +83,7 @@ void main() {
           equals(
             MatchMakingState(
               status: MatchMakingStatus.initial,
-              match: Match(
+              match: DraftMatch(
                 id: '',
                 host: '',
               ),
@@ -97,7 +97,7 @@ void main() {
       expect(
         MatchMakingState(
           status: MatchMakingStatus.initial,
-          match: Match(
+          match: DraftMatch(
             id: '',
             host: '',
           ),
@@ -105,7 +105,7 @@ void main() {
         equals(
           MatchMakingState(
             status: MatchMakingStatus.failed,
-            match: Match(
+            match: DraftMatch(
               id: '',
               host: '',
             ),
@@ -116,12 +116,12 @@ void main() {
       expect(
         MatchMakingState(
           status: MatchMakingStatus.initial,
-          match: Match(
+          match: DraftMatch(
             id: '',
             host: '',
           ),
         ).copyWith(
-          match: Match(
+          match: DraftMatch(
             id: '1',
             host: '',
           ),
@@ -129,7 +129,7 @@ void main() {
         equals(
           MatchMakingState(
             status: MatchMakingStatus.initial,
-            match: Match(
+            match: DraftMatch(
               id: '1',
               host: '',
             ),

--- a/test/match_making/views/match_making_view_test.dart
+++ b/test/match_making/views/match_making_view_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart' hide Card;
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:game_domain/game_domain.dart' hide Match;
+import 'package:game_domain/game_domain.dart';
 import 'package:go_router/go_router.dart';
 import 'package:match_maker_repository/match_maker_repository.dart';
 import 'package:mocktail/mocktail.dart';
@@ -102,7 +102,7 @@ void main() {
           mockState(
             MatchMakingState(
               status: MatchMakingStatus.processing,
-              match: Match(
+              match: DraftMatch(
                 id: 'matchId',
                 host: 'hostId',
                 guest: 'guestId',
@@ -124,7 +124,7 @@ void main() {
           mockState(
             MatchMakingState(
               status: MatchMakingStatus.processing,
-              match: Match(
+              match: DraftMatch(
                 id: 'matchId',
                 host: 'hostId',
                 guest: 'guestId',
@@ -169,7 +169,7 @@ void main() {
         mockState(
           MatchMakingState(
             status: MatchMakingStatus.completed,
-            match: Match(
+            match: DraftMatch(
               id: 'matchId',
               host: 'hostId',
               guest: 'guestId',


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
I renamed the `Match` class (from `MatchMakerRepository`) to `DraftMatch` to accurately reflect its use as a partially-formed match. This is to avoid naming conflicts that can be annoying.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
