### PR TITLE
feat: adding build share url methods to api client

### DIFF
--- a/packages/api_client/lib/src/api_client.dart
+++ b/packages/api_client/lib/src/api_client.dart
@@ -212,6 +212,16 @@ class ApiClient {
       );
     }
   }
+
+  /// Returns the share page url for the specified [deckId].
+  String shareHandUrl(String deckId) {
+    return '$_base/public/share?deckId=$deckId';
+  }
+
+  /// Returns the share page url for the specified [cardId].
+  String shareCardUrl(String cardId) {
+    return '$_base/public/share?cardId=$cardId';
+  }
 }
 
 extension on http.Response {

--- a/packages/api_client/test/src/api_client_test.dart
+++ b/packages/api_client/test/src/api_client_test.dart
@@ -464,6 +464,24 @@ void main() {
       });
     });
 
+    group('shareHandUrl', () {
+      test('returns the correct url', () {
+        expect(
+          subject.shareHandUrl('id'),
+          equals('http://baseurl.com/public/share?deckId=id'),
+        );
+      });
+    });
+
+    group('shareCardUrl', () {
+      test('returns the correct url', () {
+        expect(
+          subject.shareCardUrl('id'),
+          equals('http://baseurl.com/public/share?cardId=id'),
+        );
+      });
+    });
+
     group('ApiClientError', () {
       test('toString returns the cause', () {
         expect(


### PR DESCRIPTION
## Description

Adds two methods in the api client that builds the share urls that should be sent in the shareable content to social networks.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
