### PR TITLE
feat(draft): allow player to chose card slot

### DIFF
--- a/lib/draft/bloc/draft_bloc.dart
+++ b/lib/draft/bloc/draft_bloc.dart
@@ -97,21 +97,17 @@ class DraftBloc extends Bloc<DraftEvent, DraftState> {
     Emitter<DraftState> emit,
   ) {
     final topCard = state.cards.first;
-    if (state.selectedCards.length == 3 ||
-        state.selectedCards.contains(topCard)) return;
+    if (state.selectedCards.contains(topCard)) return;
     _audioController.playSfx(Assets.sfx.addToHand);
 
-    final selectedCards = [
-      ...state.selectedCards,
-      topCard,
-    ];
+    final selectedCards = List.of(state.selectedCards);
+    selectedCards[event.index] = topCard;
 
-    final selectionCompleted = selectedCards.length == 3;
+    final selectionCompleted =
+        selectedCards.length == 3 && !selectedCards.contains(null);
 
-    final cards = selectionCompleted ? null : _dismissTopCard();
-    if (cards != null) {
-      _playHoloReveal(cards);
-    }
+    final cards = _dismissTopCard();
+    _playHoloReveal(cards);
 
     emit(
       state.copyWith(

--- a/lib/draft/bloc/draft_event.dart
+++ b/lib/draft/bloc/draft_event.dart
@@ -44,8 +44,10 @@ class CardSwipeStarted extends DraftEvent {
 }
 
 class SelectCard extends DraftEvent {
-  const SelectCard();
+  const SelectCard(this.index);
+
+  final int index;
 
   @override
-  List<Object> get props => [];
+  List<Object> get props => [index];
 }

--- a/lib/draft/bloc/draft_state.dart
+++ b/lib/draft/bloc/draft_state.dart
@@ -19,19 +19,19 @@ class DraftState extends Equatable {
   const DraftState.initial()
       : this(
           cards: const [],
-          selectedCards: const [],
+          selectedCards: const [null, null, null],
           status: DraftStateStatus.initial,
           firstCardOpacity: 1,
         );
 
   final List<Card> cards;
-  final List<Card> selectedCards;
+  final List<Card?> selectedCards;
   final DraftStateStatus status;
   final double firstCardOpacity;
 
   DraftState copyWith({
     List<Card>? cards,
-    List<Card>? selectedCards,
+    List<Card?>? selectedCards,
     DraftStateStatus? status,
     double? firstCardOpacity,
   }) {

--- a/lib/draft/views/draft_view.dart
+++ b/lib/draft/views/draft_view.dart
@@ -205,7 +205,7 @@ class SelectedCard extends StatelessWidget {
       cursor: SystemMouseCursors.click,
       child: GestureDetector(
         onTap: () {
-          bloc.add(const SelectCard());
+          bloc.add(SelectCard(index));
         },
         child: Container(
           height: 145,
@@ -280,7 +280,9 @@ class _BottomBar extends StatelessWidget {
                 context,
                 () => GoRouter.of(context).goNamed(
                   'match_making',
-                  extra: MatchMakingPageData(deck: state.selectedCards),
+                  extra: MatchMakingPageData(
+                    deck: state.selectedCards.cast<Card>(),
+                  ),
                 ),
               ),
               onLongPress: () => showPrivateMatchDialog(context),
@@ -317,7 +319,7 @@ class _BottomBar extends StatelessWidget {
     showDialog<String?>(
       context: context,
       builder: (_) => _JoinPrivateMatchDialog(
-        selectedCards: state.selectedCards,
+        selectedCards: state.selectedCards.cast<Card>(),
         routerNeglectCall: routerNeglectCall,
       ),
     ).then((inviteCode) {
@@ -329,7 +331,7 @@ class _BottomBar extends StatelessWidget {
             queryParams: {
               'inviteCode': inviteCode,
             },
-            extra: MatchMakingPageData(deck: state.selectedCards),
+            extra: MatchMakingPageData(deck: state.selectedCards.cast<Card>()),
           ),
         );
       }

--- a/test/draft/bloc/draft_bloc_test.dart
+++ b/test/draft/bloc/draft_bloc_test.dart
@@ -80,13 +80,13 @@ void main() {
       expect: () => [
         DraftState(
           cards: const [],
-          selectedCards: const [],
+          selectedCards: const [null, null, null],
           status: DraftStateStatus.deckLoading,
           firstCardOpacity: 1,
         ),
         DraftState(
           cards: cards,
-          selectedCards: const [],
+          selectedCards: const [null, null, null],
           status: DraftStateStatus.deckLoaded,
           firstCardOpacity: 1,
         ),
@@ -142,7 +142,7 @@ void main() {
       ),
       seed: () => DraftState(
         cards: cards,
-        selectedCards: const [],
+        selectedCards: const [null, null, null],
         status: DraftStateStatus.deckLoaded,
         firstCardOpacity: 1,
       ),
@@ -155,7 +155,7 @@ void main() {
             cards.last,
             ...cards.getRange(0, cards.length - 1),
           ],
-          selectedCards: const [],
+          selectedCards: const [null, null, null],
           status: DraftStateStatus.deckLoaded,
           firstCardOpacity: 1,
         ),
@@ -170,7 +170,7 @@ void main() {
       ),
       seed: () => DraftState(
         cards: [commonCard, rareCard],
-        selectedCards: const [],
+        selectedCards: const [null, null, null],
         status: DraftStateStatus.deckLoaded,
         firstCardOpacity: 1,
       ),
@@ -190,7 +190,7 @@ void main() {
       ),
       seed: () => DraftState(
         cards: cards,
-        selectedCards: const [],
+        selectedCards: const [null, null, null],
         status: DraftStateStatus.deckLoaded,
         firstCardOpacity: 1,
       ),
@@ -203,7 +203,7 @@ void main() {
             ...cards.getRange(1, cards.length),
             cards.first,
           ],
-          selectedCards: const [],
+          selectedCards: const [null, null, null],
           status: DraftStateStatus.deckLoaded,
           firstCardOpacity: 1,
         ),
@@ -218,7 +218,7 @@ void main() {
       ),
       seed: () => DraftState(
         cards: [commonCard, rareCard],
-        selectedCards: const [],
+        selectedCards: const [null, null, null],
         status: DraftStateStatus.deckLoaded,
         firstCardOpacity: 1,
       ),
@@ -238,7 +238,7 @@ void main() {
       ),
       seed: () => DraftState(
         cards: cards,
-        selectedCards: const [],
+        selectedCards: const [null, null, null],
         status: DraftStateStatus.deckLoaded,
         firstCardOpacity: .2,
       ),
@@ -251,7 +251,7 @@ void main() {
             ...cards.getRange(1, cards.length),
             cards.first,
           ],
-          selectedCards: const [],
+          selectedCards: const [null, null, null],
           status: DraftStateStatus.deckLoaded,
           firstCardOpacity: 1,
         ),
@@ -265,7 +265,7 @@ void main() {
       ),
       seed: () => DraftState(
         cards: [commonCard, rareCard],
-        selectedCards: const [],
+        selectedCards: const [null, null, null],
         status: DraftStateStatus.deckLoaded,
         firstCardOpacity: 1,
       ),
@@ -285,7 +285,7 @@ void main() {
       ),
       seed: () => DraftState(
         cards: cards,
-        selectedCards: const [],
+        selectedCards: const [null, null, null],
         status: DraftStateStatus.deckLoaded,
         firstCardOpacity: 1,
       ),
@@ -295,7 +295,7 @@ void main() {
       expect: () => [
         DraftState(
           cards: cards,
-          selectedCards: const [],
+          selectedCards: const [null, null, null],
           status: DraftStateStatus.deckLoaded,
           firstCardOpacity: .9,
         ),
@@ -310,7 +310,7 @@ void main() {
       ),
       seed: () => DraftState(
         cards: cards,
-        selectedCards: const [],
+        selectedCards: const [null, null, null],
         status: DraftStateStatus.deckLoaded,
         firstCardOpacity: 1,
       ),
@@ -331,12 +331,12 @@ void main() {
       ),
       seed: () => DraftState(
         cards: cards,
-        selectedCards: const [],
+        selectedCards: const [null, null, null],
         status: DraftStateStatus.deckLoaded,
         firstCardOpacity: 1,
       ),
       act: (bloc) {
-        bloc.add(SelectCard());
+        bloc.add(SelectCard(0));
       },
       expect: () => [
         DraftState(
@@ -344,8 +344,43 @@ void main() {
             ...cards.getRange(1, cards.length),
             cards.first,
           ],
-          selectedCards: [cards.first],
+          selectedCards: [cards.first, null, null],
           status: DraftStateStatus.deckLoaded,
+          firstCardOpacity: 1,
+        ),
+      ],
+      verify: (_) {
+        final captured =
+            verify(() => audioController.playSfx(captureAny())).captured;
+        final sfx = captured.first;
+        expect(sfx, isA<String>());
+        expect(sfx as String, Assets.sfx.addToHand);
+      },
+    );
+
+    blocTest<DraftBloc, DraftState>(
+      'can still select a card when the deck is full',
+      build: () => DraftBloc(
+        gameResource: gameResource,
+        audioController: audioController,
+      ),
+      seed: () => DraftState(
+        cards: cards,
+        selectedCards: [cards[1], cards[2], cards[3]],
+        status: DraftStateStatus.deckSelected,
+        firstCardOpacity: 1,
+      ),
+      act: (bloc) {
+        bloc.add(SelectCard(2));
+      },
+      expect: () => [
+        DraftState(
+          cards: [
+            ...cards.getRange(1, cards.length),
+            cards.first,
+          ],
+          selectedCards: [cards[1], cards[2], cards.first],
+          status: DraftStateStatus.deckSelected,
           firstCardOpacity: 1,
         ),
       ],
@@ -366,17 +401,20 @@ void main() {
       ),
       seed: () => DraftState(
         cards: cards,
-        selectedCards: [cards[2], cards[3]],
+        selectedCards: [cards[2], null, cards[3]],
         status: DraftStateStatus.deckLoaded,
         firstCardOpacity: 1,
       ),
       act: (bloc) {
-        bloc.add(SelectCard());
+        bloc.add(SelectCard(1));
       },
       expect: () => [
         DraftState(
-          cards: cards,
-          selectedCards: [cards[2], cards[3], cards.first],
+          cards: [
+            ...cards.getRange(1, cards.length),
+            cards.first,
+          ],
+          selectedCards: [cards[2], cards.first, cards[3]],
           status: DraftStateStatus.deckSelected,
           firstCardOpacity: 1,
         ),
@@ -397,13 +435,13 @@ void main() {
       expect: () => [
         DraftState(
           cards: const [],
-          selectedCards: const [],
+          selectedCards: const [null, null, null],
           status: DraftStateStatus.deckLoading,
           firstCardOpacity: 1,
         ),
         DraftState(
           cards: const [],
-          selectedCards: const [],
+          selectedCards: const [null, null, null],
           status: DraftStateStatus.deckFailed,
           firstCardOpacity: 1,
         ),

--- a/test/draft/bloc/draft_event_test.dart
+++ b/test/draft/bloc/draft_event_test.dart
@@ -93,15 +93,19 @@ void main() {
   group('SelectCard', () {
     test('can be instantiated', () {
       expect(
-        SelectCard(),
+        SelectCard(0),
         isNotNull,
       );
     });
 
     test('supports equality', () {
       expect(
-        SelectCard(),
-        equals(SelectCard()),
+        SelectCard(0),
+        equals(SelectCard(0)),
+      );
+      expect(
+        SelectCard(0),
+        isNot(equals(SelectCard(1))),
       );
     });
   });

--- a/test/draft/bloc/draft_state_test.dart
+++ b/test/draft/bloc/draft_state_test.dart
@@ -44,7 +44,7 @@ void main() {
         equals(
           DraftState(
             cards: const [],
-            selectedCards: const [],
+            selectedCards: const [null, null, null],
             status: DraftStateStatus.initial,
             firstCardOpacity: 1,
           ),

--- a/test/draft/views/draft_view_test.dart
+++ b/test/draft/views/draft_view_test.dart
@@ -126,7 +126,7 @@ void main() {
       await tester.tap(find.byKey(ValueKey('SelectedCard0')));
       await tester.pumpAndSettle();
 
-      verify(() => draftBloc.add(SelectCard())).called(1);
+      verify(() => draftBloc.add(SelectCard(0))).called(1);
     });
 
     testWidgets('can go to the next card by swiping', (tester) async {


### PR DESCRIPTION


## Description
In preparation for allowing users to drag-and-drop cards for the draft screen, this PR allows them to pick which slot a card is going into.


https://user-images.githubusercontent.com/18384371/234681804-1446db56-efca-4f48-bc83-57d3d29d6bf0.mov



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
