### PR TITLE
fix: avoiding the prompts loader to hit rate limits

### DIFF
--- a/api/tools/data_loader/lib/src/data_loader.dart
+++ b/api/tools/data_loader/lib/src/data_loader.dart
@@ -46,6 +46,7 @@ class DataLoader {
     for (final prompt in prompts) {
       await _promptRepository.createPromptTerm(prompt);
       progress++;
+
       /// So we don't hit rate limits.
       await Future<void>.delayed(const Duration(milliseconds: 50));
       onProgress(progress, prompts.length);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adding a small delayed on the insertion of the prompts in the DB so we don't hit rate limits of firebase.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
