### PR TITLE
feat: update end of game flow

### DIFF
--- a/lib/game/widgets/quit_game_dialog.dart
+++ b/lib/game/widgets/quit_game_dialog.dart
@@ -31,7 +31,7 @@ class QuitGameDialog extends StatelessWidget {
         ),
         const SizedBox(height: TopDashSpacing.xlg),
         RoundedButton.text(
-          l10n.quit,
+          l10n.continueLabel,
           onPressed: onConfirm,
         ),
         const SizedBox(height: TopDashSpacing.sm),

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -114,9 +114,17 @@
   "@cancel": {
     "description": "Label showing to cancel an action"
   },
+  "continueLabel": "CONTINUE",
+  "@continueLabel": {
+    "description": "Label showing to continue an action"
+  },
   "enter": "ENTER",
   "@enter": {
     "description": "Label showing to enter"
+  },
+  "submitScore": "SUBMIT SCORE",
+  "@submitScore": {
+    "description": "Label showing to submit score"
   },
   "useCard": "Use card",
   "@useCard": {
@@ -224,7 +232,7 @@
   "@quitGameDialogTitle": {
     "description": "Title of the quit game dialog"
   },
-  "quitGameDialogDescription": "You will lose your current hand and active winning streak.",
+  "quitGameDialogDescription": "You will lose your current team and end your winning streak.",
   "@quitGameDialogDescription": {
     "description": "Description of the quit game dialog"
   },

--- a/lib/share/views/share_hand_page.dart
+++ b/lib/share/views/share_hand_page.dart
@@ -6,8 +6,7 @@ import 'package:top_dash/audio/audio.dart';
 import 'package:top_dash/gen/assets.gen.dart';
 import 'package:top_dash/info/info.dart';
 import 'package:top_dash/l10n/l10n.dart';
-import 'package:top_dash/share/views/views.dart';
-import 'package:top_dash/share/widgets/widgets.dart';
+import 'package:top_dash/share/share.dart';
 import 'package:top_dash/utils/utils.dart';
 import 'package:top_dash_ui/top_dash_ui.dart';
 
@@ -39,6 +38,8 @@ class ShareHandPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    final isPhoneWidth = MediaQuery.sizeOf(context).width < 400;
+
     return IoFlipScaffold(
       body: Column(
         children: [
@@ -52,9 +53,7 @@ class ShareHandPage extends StatelessWidget {
           const SizedBox(height: TopDashSpacing.xxlg),
           Align(
             alignment: Alignment.topCenter,
-            child: CardFan(
-              cards: deck,
-            ),
+            child: CardFan(cards: deck),
           ),
           Text(
             initials,
@@ -76,42 +75,55 @@ class ShareHandPage extends StatelessWidget {
             ],
           ),
           const Spacer(),
-          IoFlipBottomBar(
-            height: 64,
-            leading: const AudioToggleButton(),
-            middle: Row(
-              mainAxisSize: MainAxisSize.min,
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: TopDashSpacing.xlg,
+              vertical: TopDashSpacing.sm,
+            ),
+            child: Row(
               children: [
-                RoundedButton.text(
-                  l10n.shareButtonLabel,
+                const AudioToggleButton(),
+                const Spacer(),
+                Flex(
+                  direction: isPhoneWidth ? Axis.vertical : Axis.horizontal,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    RoundedButton.text(
+                      l10n.shareButtonLabel,
+                      onPressed: () => TopDashDialog.show(
+                        context,
+                        child: ShareHandDialog(
+                          cards: deck,
+                          deckId: deckId,
+                          initials: initials,
+                          wins: wins,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(
+                      width: TopDashSpacing.md,
+                      height: TopDashSpacing.md,
+                    ),
+                    RoundedButton.text(
+                      l10n.mainMenuButtonLabel,
+                      backgroundColor: TopDashColors.seedBlack,
+                      foregroundColor: TopDashColors.seedWhite,
+                      borderColor: TopDashColors.seedPaletteNeutral40,
+                      onPressed: () => GoRouter.of(context).go('/'),
+                    ),
+                  ],
+                ),
+                const Spacer(),
+                RoundedButton.svg(
+                  key: const Key('share_page_info_button'),
+                  Assets.icons.info,
                   onPressed: () => TopDashDialog.show(
                     context,
-                    child: ShareHandDialog(
-                      cards: deck,
-                      deckId: deckId,
-                      initials: initials,
-                      wins: wins,
-                    ),
+                    child: const InfoView(),
+                    onClose: context.maybePop,
                   ),
                 ),
-                const SizedBox(width: TopDashSpacing.sm),
-                RoundedButton.text(
-                  l10n.mainMenuButtonLabel,
-                  backgroundColor: TopDashColors.seedBlack,
-                  foregroundColor: TopDashColors.seedWhite,
-                  borderColor: TopDashColors.seedPaletteNeutral40,
-                  onPressed: () => GoRouter.of(context).go('/'),
-                ),
               ],
-            ),
-            trailing: RoundedButton.svg(
-              key: const Key('share_page_info_button'),
-              Assets.icons.info,
-              onPressed: () => TopDashDialog.show(
-                context,
-                child: const InfoView(),
-                onClose: context.maybePop,
-              ),
             ),
           ),
           const SizedBox(height: TopDashSpacing.md),

--- a/test/game/views/game_summary_test.dart
+++ b/test/game/views/game_summary_test.dart
@@ -368,6 +368,7 @@ void main() {
         (tester) async {
           final goRouter = MockGoRouter();
 
+          when(() => bloc.isHost).thenReturn(false);
           defaultMockState();
           await tester.pumpSubject(
             bloc,
@@ -382,17 +383,19 @@ void main() {
       );
 
       testWidgets(
-        'pops navigation when the quit button is tapped and canceled',
+        'pops navigation when the submit score button is tapped and canceled',
         (tester) async {
           final goRouter = MockGoRouter();
 
+          when(() => bloc.isHost).thenReturn(false);
+          when(() => bloc.playerCards).thenReturn([]);
           defaultMockState();
           await tester.pumpSubject(
             bloc,
             goRouter: goRouter,
           );
 
-          await tester.tap(find.text(tester.l10n.quit));
+          await tester.tap(find.text(tester.l10n.submitScore));
           await tester.pumpAndSettle();
 
           expect(find.byType(QuitGameDialog), findsOneWidget);
@@ -421,11 +424,11 @@ void main() {
       });
 
       testWidgets(
-        'pops navigation when the quit button is tapped and confirmed and '
-        'adds LeaderboardEntryRequested event to bloc if player score card '
-        'initials is null',
+        'pops navigation when the submit score button is tapped by winner '
+        'and confirmed and adds LeaderboardEntryRequested event to bloc',
         (tester) async {
           final goRouter = MockGoRouter();
+          when(() => bloc.isHost).thenReturn(false);
           when(() => bloc.playerCards).thenReturn([]);
           defaultMockState();
 
@@ -440,12 +443,12 @@ void main() {
             router: goRouter,
           );
 
-          await tester.tap(find.text(tester.l10n.quit));
+          await tester.tap(find.text(tester.l10n.submitScore));
           await tester.pumpAndSettle();
 
           expect(find.byType(QuitGameDialog), findsOneWidget);
 
-          await tester.tap(find.text(tester.l10n.quit).last);
+          await tester.tap(find.text(tester.l10n.continueLabel));
           await tester.pumpAndSettle();
 
           verify(goRouter.pop).called(1);
@@ -465,16 +468,12 @@ void main() {
       );
 
       testWidgets(
-        'routes to share hand page when the quit button is tapped '
-        'and confirmed and player score card has initials',
+        'adds LeaderboardEntryRequested event to bloc when submit score button '
+        'is tapped by loser',
         (tester) async {
           final goRouter = MockGoRouter();
-
           when(() => bloc.playerCards).thenReturn([]);
-
-          defaultMockState(
-            scoreCard: ScoreCard(id: 'id', initials: 'AAA'),
-          );
+          defaultMockState();
 
           await tester.pumpApp(
             BlocProvider<GameBloc>.value(
@@ -487,22 +486,18 @@ void main() {
             router: goRouter,
           );
 
-          await tester.tap(find.text(tester.l10n.quit));
-          await tester.pumpAndSettle();
-
-          expect(find.byType(QuitGameDialog), findsOneWidget);
-
-          await tester.tap(find.text(tester.l10n.quit).last);
+          await tester.tap(find.text(tester.l10n.submitScore));
           await tester.pumpAndSettle();
 
           verify(
-            () => goRouter.goNamed(
-              'share_hand',
-              extra: ShareHandPageData(
-                initials: 'AAA',
-                wins: 0,
-                deckId: '',
-                deck: const [],
+            () => bloc.add(
+              LeaderboardEntryRequested(
+                shareHandPageData: ShareHandPageData(
+                  initials: '',
+                  deck: const [],
+                  deckId: '',
+                  wins: 0,
+                ),
               ),
             ),
           ).called(1);

--- a/test/game/widgets/quit_game_dialog_test.dart
+++ b/test/game/widgets/quit_game_dialog_test.dart
@@ -23,7 +23,7 @@ void main() {
     });
 
     testWidgets(
-      'calls onConfirm when the quit button is tapped',
+      'calls onConfirm when the continue button is tapped',
       (tester) async {
         var onConfirmCalled = false;
 
@@ -33,7 +33,7 @@ void main() {
           ),
         );
 
-        await tester.tap(find.text(tester.l10n.quit));
+        await tester.tap(find.text(tester.l10n.continueLabel));
 
         expect(onConfirmCalled, isTrue);
       },

--- a/test/share/views/share_hand_page_test.dart
+++ b/test/share/views/share_hand_page_test.dart
@@ -36,11 +36,13 @@ const pageData =
 
 void main() {
   late GoRouterState goRouterState;
+
   setUp(() {
     goRouterState = _MockGoRouterState();
     when(() => goRouterState.extra).thenReturn(pageData);
     when(() => goRouterState.queryParams).thenReturn({});
   });
+
   group('ShareHandPage', () {
     test('routeBuilder returns a ShareHandPage', () {
       expect(
@@ -52,6 +54,7 @@ void main() {
             .having((page) => page.initials, 'initials', pageData.initials),
       );
     });
+
     testWidgets('renders', (tester) async {
       await tester.pumpSubject();
       expect(find.byType(ShareHandPage), findsOneWidget);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Updates the end of game flow so that only the winner has the "next match" option and instead of "quit", it's now "submit score" where initials have to be entered every time. If a player loses, tapping "submit score" will directly go to the initials form, but the winner will see the quit game dialog before continuing to the initials form.

Also fixes an issue where the share hand page was incorrectly rendering the footer buttons.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
