### PR TITLE
fix: streak when player loses

### DIFF
--- a/api/packages/game_domain/lib/src/models/score_card.dart
+++ b/api/packages/game_domain/lib/src/models/score_card.dart
@@ -14,8 +14,10 @@ class ScoreCard extends Equatable {
     this.wins = 0,
     this.longestStreak = 0,
     this.currentStreak = 0,
-    this.currentDeck = '',
+    this.latestStreak = 0,
     this.longestStreakDeck = '',
+    this.currentDeck = '',
+    this.latestDeck = '',
     this.initials,
   });
 
@@ -39,13 +41,23 @@ class ScoreCard extends Equatable {
   @JsonKey()
   final int currentStreak;
 
-  /// Unique identifier of the deck played in the session
+  /// Latest streak of wins in the session. When a player loses,
+  /// the [currentStreak] is reset, and this [latestStreak] is used after
+  /// the match is finished.
+  @JsonKey()
+  final int latestStreak;
+
+  /// Unique identifier of the deck which was used to set the [longestStreak].
+  @JsonKey()
+  final String longestStreakDeck;
+
+  /// Unique identifier of the deck played in the session.
   @JsonKey()
   final String currentDeck;
 
-  /// Unique identifier of the deck which was used to set the [longestStreak]
+  /// Unique identifier of the deck played in the last session.
   @JsonKey()
-  final String longestStreakDeck;
+  final String latestDeck;
 
   /// Initials of the player.
   @JsonKey()
@@ -60,8 +72,10 @@ class ScoreCard extends Equatable {
         wins,
         longestStreak,
         currentStreak,
-        currentDeck,
+        latestStreak,
         longestStreakDeck,
+        currentDeck,
+        latestDeck,
         initials,
       ];
 }

--- a/api/packages/game_domain/lib/src/models/score_card.g.dart
+++ b/api/packages/game_domain/lib/src/models/score_card.g.dart
@@ -11,8 +11,10 @@ ScoreCard _$ScoreCardFromJson(Map<String, dynamic> json) => ScoreCard(
       wins: json['wins'] as int? ?? 0,
       longestStreak: json['longestStreak'] as int? ?? 0,
       currentStreak: json['currentStreak'] as int? ?? 0,
-      currentDeck: json['currentDeck'] as String? ?? '',
+      latestStreak: json['latestStreak'] as int? ?? 0,
       longestStreakDeck: json['longestStreakDeck'] as String? ?? '',
+      currentDeck: json['currentDeck'] as String? ?? '',
+      latestDeck: json['latestDeck'] as String? ?? '',
       initials: json['initials'] as String?,
     );
 
@@ -21,7 +23,9 @@ Map<String, dynamic> _$ScoreCardToJson(ScoreCard instance) => <String, dynamic>{
       'wins': instance.wins,
       'longestStreak': instance.longestStreak,
       'currentStreak': instance.currentStreak,
-      'currentDeck': instance.currentDeck,
+      'latestStreak': instance.latestStreak,
       'longestStreakDeck': instance.longestStreakDeck,
+      'currentDeck': instance.currentDeck,
+      'latestDeck': instance.latestDeck,
       'initials': instance.initials,
     };

--- a/api/packages/game_domain/test/src/models/score_card_test.dart
+++ b/api/packages/game_domain/test/src/models/score_card_test.dart
@@ -18,8 +18,10 @@ void main() {
       wins: 1,
       longestStreak: 1,
       currentStreak: 1,
-      currentDeck: 'deckId',
+      latestStreak: 1,
       longestStreakDeck: 'longestId',
+      currentDeck: 'deckId',
+      latestDeck: 'latestId',
       initials: 'initials',
     );
 
@@ -31,8 +33,10 @@ void main() {
           'wins': 1,
           'longestStreak': 1,
           'currentStreak': 1,
-          'currentDeck': 'deckId',
+          'latestStreak': 1,
           'longestStreakDeck': 'longestId',
+          'currentDeck': 'deckId',
+          'latestDeck': 'latestId',
           'initials': 'initials',
         }),
       );
@@ -45,8 +49,10 @@ void main() {
           'wins': 1,
           'longestStreak': 1,
           'currentStreak': 1,
-          'currentDeck': 'deckId',
+          'latestStreak': 1,
           'longestStreakDeck': 'longestId',
+          'currentDeck': 'deckId',
+          'latestDeck': 'latestId',
           'initials': 'initials',
         }),
         equals(scoreCard),
@@ -59,83 +65,162 @@ void main() {
         equals(ScoreCard(id: '')),
       );
 
+      // different id
       expect(
         ScoreCard(
           id: '',
           wins: 1,
-          currentStreak: 1,
           longestStreak: 1,
-          currentDeck: 'deckId',
+          currentStreak: 1,
+          latestStreak: 1,
           longestStreakDeck: 'longestId',
+          currentDeck: 'deckId',
+          latestDeck: 'latestId',
           initials: 'initials',
         ),
         isNot(
           equals(scoreCard),
         ),
       );
+
+      // different wins
       expect(
         ScoreCard(
           id: 'id',
           wins: 2,
-          currentStreak: 1,
           longestStreak: 1,
-          currentDeck: 'deckId',
+          currentStreak: 1,
+          latestStreak: 1,
           longestStreakDeck: 'longestId',
+          currentDeck: 'deckId',
+          latestDeck: 'latestId',
           initials: 'initials',
         ),
         isNot(
           equals(scoreCard),
         ),
       );
+
+      // different longestStreak
       expect(
         ScoreCard(
           id: 'id',
           wins: 1,
-          currentStreak: 2,
-          longestStreak: 1,
-          currentDeck: 'deckId',
-          longestStreakDeck: 'longestId',
-          initials: 'initials',
-        ),
-        isNot(
-          equals(scoreCard),
-        ),
-      );
-      expect(
-        ScoreCard(
-          id: 'id',
-          wins: 1,
-          currentStreak: 1,
           longestStreak: 2,
-          currentDeck: 'deckId',
+          currentStreak: 1,
+          latestStreak: 1,
           longestStreakDeck: 'longestId',
+          currentDeck: 'deckId',
+          latestDeck: 'latestId',
           initials: 'initials',
         ),
         isNot(
           equals(scoreCard),
         ),
       );
+
+      // different currentStreak
       expect(
         ScoreCard(
           id: 'id',
           wins: 1,
-          currentStreak: 1,
           longestStreak: 1,
+          currentStreak: 2,
+          latestStreak: 1,
           longestStreakDeck: 'longestId',
+          currentDeck: 'deckId',
+          latestDeck: 'latestId',
           initials: 'initials',
         ),
         isNot(
           equals(scoreCard),
         ),
       );
+
+      // different latestStreak
       expect(
         ScoreCard(
           id: 'id',
           wins: 1,
-          currentStreak: 1,
           longestStreak: 1,
+          currentStreak: 1,
+          latestStreak: 2,
+          longestStreakDeck: 'longestId',
           currentDeck: 'deckId',
+          latestDeck: 'latestId',
           initials: 'initials',
+        ),
+        isNot(
+          equals(scoreCard),
+        ),
+      );
+
+      // different longestStreakDeck
+      expect(
+        ScoreCard(
+          id: 'id',
+          wins: 1,
+          longestStreak: 1,
+          currentStreak: 1,
+          latestStreak: 1,
+          longestStreakDeck: '-',
+          currentDeck: 'deckId',
+          latestDeck: 'latestId',
+          initials: 'initials',
+        ),
+        isNot(
+          equals(scoreCard),
+        ),
+      );
+
+      // different currentDeck
+      expect(
+        ScoreCard(
+          id: 'id',
+          wins: 1,
+          longestStreak: 1,
+          currentStreak: 1,
+          latestStreak: 1,
+          longestStreakDeck: 'longestId',
+          currentDeck: '-',
+          latestDeck: 'latestId',
+          initials: 'initials',
+        ),
+        isNot(
+          equals(scoreCard),
+        ),
+      );
+
+      // different latestDeck
+      expect(
+        ScoreCard(
+          id: 'id',
+          wins: 1,
+          longestStreak: 1,
+          currentStreak: 1,
+          latestStreak: 1,
+          longestStreakDeck: 'longestId',
+          currentDeck: 'deckId',
+          latestDeck: '-',
+          initials: 'initials',
+        ),
+        isNot(
+          equals(scoreCard),
+        ),
+      );
+
+      // different initials
+      expect(
+        ScoreCard(
+          id: 'id',
+          wins: 1,
+          longestStreak: 1,
+          currentStreak: 1,
+          latestStreak: 1,
+          longestStreakDeck: 'longestId',
+          currentDeck: 'deckId',
+          latestDeck: 'latestId',
+          initials: '-',
         ),
         isNot(
           equals(scoreCard),

--- a/api/packages/match_repository/lib/src/match_repository.dart
+++ b/api/packages/match_repository/lib/src/match_repository.dart
@@ -271,10 +271,8 @@ class MatchRepository {
   }
 
   Future<void> _playerWon(ScoreCard scoreCard) async {
-    var newStreak = scoreCard.longestStreak;
-    if (scoreCard.currentStreak + 1 > scoreCard.longestStreak) {
-      newStreak = scoreCard.currentStreak + 1;
-    }
+    final newStreak = scoreCard.currentStreak + 1;
+    final isLongestStreak = newStreak > scoreCard.longestStreak;
 
     await _dbClient.update(
       'score_cards',
@@ -282,12 +280,12 @@ class MatchRepository {
         id: scoreCard.id,
         data: {
           'wins': scoreCard.wins + 1,
-          'currentStreak': scoreCard.currentStreak + 1,
-          'longestStreak': newStreak,
+          'currentStreak': newStreak,
+          'latestStreak': newStreak,
+          if (isLongestStreak) 'longestStreak': newStreak,
           'currentDeck': scoreCard.currentDeck,
-          'longestStreakDeck': newStreak > scoreCard.longestStreak
-              ? scoreCard.currentDeck
-              : scoreCard.longestStreakDeck,
+          'latestDeck': scoreCard.currentDeck,
+          if (isLongestStreak) 'longestStreakDeck': scoreCard.currentDeck,
         },
       ),
     );
@@ -298,8 +296,11 @@ class MatchRepository {
       'score_cards',
       DbEntityRecord(
         id: scoreCard.id,
-        data: const {
+        data: {
           'currentStreak': 0,
+          if (scoreCard.currentDeck != scoreCard.latestDeck) 'latestStreak': 0,
+          'currentDeck': scoreCard.currentDeck,
+          'latestDeck': scoreCard.currentDeck,
         },
       ),
     );

--- a/api/packages/match_repository/test/src/match_repository_test.dart
+++ b/api/packages/match_repository/test/src/match_repository_test.dart
@@ -661,9 +661,11 @@ void main() {
                 data: {
                   'wins': 1,
                   'currentStreak': 1,
+                  'latestStreak': 1,
                   'longestStreak': 1,
-                  'longestStreakDeck': hostDeck.id,
                   'currentDeck': hostDeck.id,
+                  'latestDeck': hostDeck.id,
+                  'longestStreakDeck': hostDeck.id,
                 },
               ),
             ),
@@ -674,8 +676,11 @@ void main() {
               'score_cards',
               DbEntityRecord(
                 id: guestDeck.userId,
-                data: const {
+                data: {
                   'currentStreak': 0,
+                  'latestStreak': 0,
+                  'currentDeck': guestDeck.id,
+                  'latestDeck': guestDeck.id,
                 },
               ),
             ),
@@ -713,8 +718,10 @@ void main() {
                 data: {
                   'wins': 1,
                   'currentStreak': 1,
+                  'latestStreak': 1,
                   'longestStreak': 1,
                   'currentDeck': guestDeck.id,
+                  'latestDeck': guestDeck.id,
                   'longestStreakDeck': guestDeck.id,
                 },
               ),
@@ -726,8 +733,11 @@ void main() {
               'score_cards',
               DbEntityRecord(
                 id: hostDeck.userId,
-                data: const {
+                data: {
                   'currentStreak': 0,
+                  'latestStreak': 0,
+                  'currentDeck': hostDeck.id,
+                  'latestDeck': hostDeck.id,
                 },
               ),
             ),
@@ -767,9 +777,9 @@ void main() {
                 data: {
                   'wins': 1,
                   'currentStreak': 1,
-                  'longestStreak': 2,
+                  'latestStreak': 1,
                   'currentDeck': guestDeck.id,
-                  'longestStreakDeck': 'longestStreakDeckId',
+                  'latestDeck': guestDeck.id,
                 },
               ),
             ),
@@ -780,8 +790,11 @@ void main() {
               'score_cards',
               DbEntityRecord(
                 id: hostDeck.userId,
-                data: const {
+                data: {
                   'currentStreak': 0,
+                  'latestStreak': 0,
+                  'currentDeck': hostDeck.id,
+                  'latestDeck': hostDeck.id,
                 },
               ),
             ),
@@ -1023,9 +1036,11 @@ void main() {
                 data: {
                   'wins': 1,
                   'currentStreak': 1,
+                  'latestStreak': 1,
                   'longestStreak': 1,
-                  'longestStreakDeck': hostDeck.id,
                   'currentDeck': hostDeck.id,
+                  'latestDeck': hostDeck.id,
+                  'longestStreakDeck': hostDeck.id,
                 },
               ),
             ),
@@ -1036,8 +1051,11 @@ void main() {
               'score_cards',
               DbEntityRecord(
                 id: guestDeck.userId,
-                data: const {
+                data: {
                   'currentStreak': 0,
+                  'latestStreak': 0,
+                  'currentDeck': guestDeck.id,
+                  'latestDeck': guestDeck.id,
                 },
               ),
             ),
@@ -1082,8 +1100,10 @@ void main() {
                 data: {
                   'wins': 1,
                   'currentStreak': 1,
+                  'latestStreak': 1,
                   'longestStreak': 1,
                   'currentDeck': guestDeck.id,
+                  'latestDeck': guestDeck.id,
                   'longestStreakDeck': guestDeck.id,
                 },
               ),
@@ -1095,8 +1115,11 @@ void main() {
               'score_cards',
               DbEntityRecord(
                 id: hostDeck.userId,
-                data: const {
+                data: {
                   'currentStreak': 0,
+                  'latestStreak': 0,
+                  'currentDeck': hostDeck.id,
+                  'latestDeck': hostDeck.id,
                 },
               ),
             ),
@@ -1143,9 +1166,9 @@ void main() {
                 data: {
                   'wins': 1,
                   'currentStreak': 1,
-                  'longestStreak': 2,
+                  'latestStreak': 1,
                   'currentDeck': guestDeck.id,
-                  'longestStreakDeck': 'longestStreakDeckId',
+                  'latestDeck': guestDeck.id,
                 },
               ),
             ),
@@ -1156,8 +1179,11 @@ void main() {
               'score_cards',
               DbEntityRecord(
                 id: hostDeck.userId,
-                data: const {
+                data: {
                   'currentStreak': 0,
+                  'latestStreak': 0,
+                  'currentDeck': hostDeck.id,
+                  'latestDeck': hostDeck.id,
                 },
               ),
             ),

--- a/lib/game/views/game_summary.dart
+++ b/lib/game/views/game_summary.dart
@@ -123,7 +123,7 @@ class _ResultView extends StatelessWidget {
             const SizedBox(width: IoFlipSpacing.sm),
             Text(
               context.l10n
-                  .gameSummaryStreak(state.playerScoreCard.currentStreak),
+                  .gameSummaryStreak(state.playerScoreCard.latestStreak),
               style: IoFlipTextStyles.mobileH6
                   .copyWith(color: IoFlipColors.seedYellow),
             ),
@@ -316,7 +316,7 @@ class GameSummaryFooter extends StatelessWidget {
             final event = LeaderboardEntryRequested(
               shareHandPageData: ShareHandPageData(
                 initials: '',
-                wins: state.playerScoreCard.currentStreak,
+                wins: state.playerScoreCard.latestStreak,
                 deckId: playerDeck.id,
                 deck: bloc.playerCards,
               ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

When match is ended, `currentStreak` is set to 0, therefore even if a previous streak was set, it resets. With this PR I introduce a new `latestStreak` field which keeps track of the current streak but is reset only if the current deck id is different from the one that set that `latestStreak`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
