### PR TITLE
chore: remove preloading canvaskit

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -310,9 +310,6 @@
             "flutter.js",
             "main.dart.js",
 
-            "canvaskit/canvaskit.wasm",
-            "canvaskit/canvaskit.js",
-
             ...additionalScripts,
             ...manifestAssets,
           ];


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Removes preloading canvaskit from `index.html`. 

In chrome, after the flutter app is running, a second canvaskit is downloaded at this path: `https://www.gstatic.com/flutter-canvaskit/f7ac42e8a273548af89f8b005179bf2b4b1bb2f1/chromium/canvaskit.wasm` which looks to be an experimental CDN since this is issue isn't happening in Safari.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
