### PR TITLE
feat: play card movement sound when clicking card switching buttons

### DIFF
--- a/lib/draft/views/draft_view.dart
+++ b/lib/draft/views/draft_view.dart
@@ -3,7 +3,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:game_domain/game_domain.dart';
 import 'package:go_router/go_router.dart';
 import 'package:io_flip/audio/audio.dart';
+import 'package:io_flip/audio/audio_controller.dart';
 import 'package:io_flip/draft/draft.dart';
+import 'package:io_flip/gen/assets.gen.dart';
 import 'package:io_flip/how_to_play/how_to_play.dart';
 import 'package:io_flip/l10n/l10n.dart';
 import 'package:io_flip/match_making/match_making.dart';
@@ -148,6 +150,7 @@ class DraftLoadedView extends StatefulWidget {
 class _DraftLoadedViewState extends State<DraftLoadedView> {
   static const _fadeInDuration = Duration(milliseconds: 450);
   static const _fadeInCurve = Curves.easeInOut;
+
   double get _uiOffset => uiVisible ? 0 : 48;
   bool uiVisible = false;
 
@@ -195,6 +198,9 @@ class _DraftLoadedViewState extends State<DraftLoadedView> {
                     opacity: showArrows ? 1 : 0,
                     child: IconButton(
                       onPressed: () {
+                        context
+                            .read<AudioController>()
+                            .playSfx(Assets.sfx.cardMovement);
                         context.read<DraftBloc>().add(const PreviousCard());
                       },
                       icon: const Icon(
@@ -216,6 +222,9 @@ class _DraftLoadedViewState extends State<DraftLoadedView> {
                     opacity: showArrows ? 1 : 0,
                     child: IconButton(
                       onPressed: () {
+                        context
+                            .read<AudioController>()
+                            .playSfx(Assets.sfx.cardMovement);
                         context.read<DraftBloc>().add(const NextCard());
                       },
                       icon: const Icon(

--- a/test/draft/views/draft_view_test.dart
+++ b/test/draft/views/draft_view_test.dart
@@ -10,6 +10,7 @@ import 'package:game_domain/game_domain.dart';
 import 'package:go_router/go_router.dart';
 import 'package:io_flip/audio/audio_controller.dart';
 import 'package:io_flip/draft/draft.dart';
+import 'package:io_flip/gen/assets.gen.dart';
 import 'package:io_flip/how_to_play/how_to_play.dart';
 import 'package:io_flip/l10n/l10n.dart';
 import 'package:io_flip/match_making/match_making.dart';
@@ -600,6 +601,33 @@ void main() {
         );
 
         expect(find.byType(DeckPack), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'plays card movement sfx correctly',
+      (tester) async {
+        mockState(
+          [
+            DraftState(
+              cards: const [card1, card2],
+              selectedCards: const [],
+              status: DraftStateStatus.deckLoaded,
+              firstCardOpacity: 1,
+            )
+          ],
+        );
+        final audioController = _MockAudioController();
+        await tester.pumpSubject(
+          draftBloc: draftBloc,
+          audioController: audioController,
+        );
+        final buttonFinder = find.byIcon(Icons.arrow_back_ios_new);
+        expect(buttonFinder, findsOneWidget);
+        await tester.tap(buttonFinder);
+        verify(
+          () => audioController.playSfx(Assets.sfx.cardMovement),
+        ).called(1);
       },
     );
   });


### PR DESCRIPTION
Previously, clicking buttons that switch between cards had no sound effects. The PR adds it.

## Description

Calling the `AudioController` to play the `card_movement` sound.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
